### PR TITLE
Specify AccelSteeringAngle for Bicycle

### DIFF
--- a/src/actions/accel_steering.jl
+++ b/src/actions/accel_steering.jl
@@ -1,6 +1,6 @@
 """
 	AccelSteeringAngle
-Allows driving the car in a circle based on the steering angle
+Allows driving the `BicycleModel` in a circle based on the steering angle
 If steering angle less than threshold 0.01 radian, just drives straight
 
 # Fields


### PR DESCRIPTION
Specify in the description of the AccelSteeringAngle that this action can only be propagated for a BicycleModel.